### PR TITLE
fix jshint error

### DIFF
--- a/src/truncate.js
+++ b/src/truncate.js
@@ -13,7 +13,7 @@ angular.module('truncate', [])
                         input = input.substr(0, lastspace);
                     }
                 }else{
-                    while(input.charAt(input.length-1) == ' '){
+                    while(input.charAt(input.length-1) === ' '){
                         input = input.substr(0, input.length -1);
                     }
                 }


### PR DESCRIPTION
``` javascript
[L19:C58] W116: Expected '===' and instead saw '=='.
while(input.charAt(input.length-1) == ' '){
```
