### PR TITLE
New 'splitcharacters' filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.DS_Store
 dist
 node_modules
+bower_components
 .idea

--- a/src/truncate.js
+++ b/src/truncate.js
@@ -22,6 +22,18 @@ angular.module('truncate', [])
             return input;
         };
     })
+    .filter('splitcharacters', function() {
+        return function (input, chars) {
+            if (isNaN(chars)) return input;
+            if (chars <= 0) return '';
+            if (input && input.length > chars) {
+                var prefix = input.substring(0, chars/2);
+                var postfix = input.substring(input.length-chars/2, input.length);
+                return prefix + '...' + postfix;
+            }
+            return input;
+        };
+    })
     .filter('words', function () {
         return function (input, words) {
             if (isNaN(words)) return input;

--- a/test/unit/filtersSpec.js
+++ b/test/unit/filtersSpec.js
@@ -94,4 +94,40 @@ describe('truncate', function () {
         });
 
     });
+
+    describe('splitcharacters', function () {
+        var characterFilter;
+
+        beforeEach(inject(function ($filter) {
+            characterFilter = $filter('splitcharacters');
+        }));
+
+        it('should do nothing to this string', function () {
+            expect(characterFilter('1234567890')).toEqual('1234567890');
+        });
+
+        it('should fail', function () {
+            expect(characterFilter(null, 30)).toNotEqual('1234567890');
+        });
+
+        it('should not trim these down', function () {
+            expect(characterFilter('1234567890', 30)).toEqual('1234567890');
+        });
+
+        it('should trim these down', function () {
+            expect(characterFilter('1234567890', 5)).toEqual('12...890');
+        });
+
+        it('should trim this down including the space', function () {
+            expect(characterFilter('123456789 10 11 12 13 14', 13)).toEqual('123456...2 13 14');
+        });
+
+        it('should handle invalid numbers', function () {
+            expect(characterFilter('1234567890', 0)).toEqual('');
+        });
+
+        it('should handle invalid chars numbers type', function () {
+            expect(characterFilter('1234567890', 'abc')).toEqual('1234567890');
+        });
+    });
 });


### PR DESCRIPTION
In my case I would like to split the string in the middle and place ellipses there.  This patch will add a new 'splitcharacters' filter that does this.
