### PR TITLE
Added Angular as a dependency to the Bower config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,5 +2,7 @@
   "name": "angular-truncate",
   "version": "0.1.0",
   "main": ["./src/truncate.js"],
-  "dependencies": {}
+  "dependencies": {
+    "angular": "~1.2.0"
+  }
 } 


### PR DESCRIPTION
It is common for front-end build tools to concatenate 3rd party JS libs together into a single file. Various tools (such as Gulp with the gulp-bower-files plugin) rely on the dependencies in a library's `bower.json` file to concatenate these files in the correct order.

Without specifying Angular itself as a dependency the angular-truncate module can end up appearing before Angular itself, which obviously breaks.

This pull request simply adds Angular as a dependency. I've specified 1.2.0 as the base version but I haven't tested this module with earlier versions. You may want to change the listed version number as necessary.

(Also, it would be great if you could tag the next release (as per #13) so that people can specify a version of angular-truncate in their own `bower.json` files, rather than having to reference your repo directly).
